### PR TITLE
Fix bug when explaining

### DIFF
--- a/lib/explain.ex
+++ b/lib/explain.ex
@@ -27,7 +27,7 @@ defmodule KinoEcto.Explain do
 
   defp explain_module(adapter) do
     case Map.fetch(@adapter_explain, adapter) do
-      {:ok, _} = module -> {:ok, module}
+      {:ok, module} -> {:ok, module}
       :error -> {:error, {:unsupported_adapter, adapter}}
     end
   end


### PR DESCRIPTION
Currently I get an exception when calling `KinoEcto.Explain.call(repo, :all, query)`. It seems there's a bug when finding the module for getting default options.

```
** (ArgumentError) you attempted to apply a function named :options on {:ok, KinoEcto.Explain.Postgres}. If you are using Kernel.apply/3, make sure the module is an atom. If you are using the dot syntax, such as module.function(), make sure the left-hand side of the dot is a module atom
    :erlang.apply({:ok, KinoEcto.Explain.Postgres}, :options, [])
    (kino_ecto 0.1.0) lib/explain.ex:20: KinoEcto.Explain.call/4
```