### PR TITLE
Escape class names in EntityRelationship

### DIFF
--- a/lib/entity_relationship/renderer.ex
+++ b/lib/entity_relationship/renderer.ex
@@ -9,8 +9,8 @@ defmodule KinoEcto.EntityRelationship.Renderer do
   end
 
   defp mermaid({struct, field, type}, acc) do
-    class_def = "class #{struct}"
-    type_def = "#{struct} : #{type} #{field}"
+    class_def = "class `#{struct}`"
+    type_def = "`#{struct}` : #{type} #{field}"
     acc ++ [class_def] ++ [type_def]
   end
 
@@ -25,8 +25,8 @@ defmodule KinoEcto.EntityRelationship.Renderer do
       end
 
     class_def = Enum.flat_map(fields, &mermaid(&1, []))
-    relationship_def = fields |> Enum.map(&elem(&1, 0)) |> Enum.map(&"#{struct} #{relantionship} #{&1}")
-    type_def = "#{struct} : #{type} #{field}"
+    relationship_def = fields |> Enum.map(&elem(&1, 0)) |> Enum.map(&"`#{struct}` #{relantionship} #{&1}")
+    type_def = "`#{struct}` : #{type} #{field}"
     acc ++ class_def ++ relationship_def ++ [type_def]
   end
 

--- a/test/entity_relationship/entity_relationship_test.exs
+++ b/test/entity_relationship/entity_relationship_test.exs
@@ -16,6 +16,7 @@ defmodule KinoEcto.EntityRelationshipTest do
     assert {:markdown, md} = Kino.Render.to_livebook(%EntityRelationship{schema: TestTeam})
 
     assert md =~ "mermaid"
-    assert md =~ "string name"
+    assert md =~ "class `KinoEcto.EntityRelationshipTest.TestTeam`"
+    assert md =~ "`KinoEcto.EntityRelationshipTest.TestTeam` : string name"
   end
 end


### PR DESCRIPTION
Escape class names in `EntityRelationship` with backticks.

Class diagrams in Mermaid only accept [underscores in class names](https://mermaid-js.github.io/mermaid/#/classDiagram?id=define-a-class).
Qualified Elixir modules are separated by periods which break Mermaid syntax.
It's not documented on that page but [revealed in tests](https://github.com/mermaid-js/mermaid/blob/09ed41b7d2cd5c8ffd50c7544bc88bd213d3c601/packages/mermaid/src/diagrams/class/classDiagram.spec.js#L12-L16) that class names can be escaped with backticks.